### PR TITLE
Compatibility Update for SMA version 12.0

### DIFF
--- a/public/Connect-Server.ps1
+++ b/public/Connect-Server.ps1
@@ -43,7 +43,7 @@ Function Connect-Server {
         $script:Headers = @{ }
         $script:Headers.Add('Accept', 'application/json')
         $script:Headers.Add('Content-Type', 'application/json')
-        $script:Headers.Add('x-dell-api-version', '8')
+        $script:Headers.Add('x-kace-api-version', '8')
 
         $RequestSplat = @{
             Uri             = $Uri
@@ -69,8 +69,8 @@ Function Connect-Server {
             break;
         }
         
-        $script:CSRFToken = $Request.Headers.'x-dell-csrf-token'
-        $script:Headers.Add("x-dell-csrf-token", "$script:CSRFToken")
+        $script:CSRFToken = $Request.Headers.'x-kace-csrf-token'
+        $script:Headers.Add("x-kace-csrf-token", "$script:CSRFToken")
 
 
     }

--- a/public/Connect-Server.ps1
+++ b/public/Connect-Server.ps1
@@ -43,6 +43,7 @@ Function Connect-Server {
         $script:Headers = @{ }
         $script:Headers.Add('Accept', 'application/json')
         $script:Headers.Add('Content-Type', 'application/json')
+        $script:Headers.Add('x-dell-api-version', '8')
         $script:Headers.Add('x-kace-api-version', '8')
 
         $RequestSplat = @{
@@ -69,7 +70,8 @@ Function Connect-Server {
             break;
         }
         
-        $script:CSRFToken = $Request.Headers.'x-kace-csrf-token'
+        $script:CSRFToken = $Request.Headers.'x-dell-csrf-token'
+        $script:Headers.Add("x-dell-csrf-token", "$script:CSRFToken")
         $script:Headers.Add("x-kace-csrf-token", "$script:CSRFToken")
 
 


### PR DESCRIPTION
Starting with KACE SMA 12.0, the headers `x-dell-api-version` becomes `x-kace-api-version`, and  `x-dell-csrf-token` becomes `x-kace-csrf-token`

https://support.quest.com/kb/276970/verifying-api-connection-with-postman

I'm guessing that some logic should also be added that can support the old and new version of the headers at the same time, if it's possible to query the SMA version and use the correct headers, or have the user supply this when they are calling the `Connect-SMAServer` cmdlet?